### PR TITLE
Using custom client secret if available

### DIFF
--- a/fortnoxAdapter/src/main/java/org/notima/businessobjects/adapter/fortnox/FileCredentialsProvider.java
+++ b/fortnoxAdapter/src/main/java/org/notima/businessobjects/adapter/fortnox/FileCredentialsProvider.java
@@ -40,14 +40,10 @@ public class FileCredentialsProvider extends FortnoxCredentialsProvider {
     public FortnoxCredentials getCredentials() throws Exception {
     	
     	FortnoxCredentials result = null;
-    	long lastRefresh = 0L;
     	
         for(FortnoxCredentials credentials : getKeyList()) {
             if (credentials.getOrgNo().equals(orgNo)){
-            	if (credentials.getLastRefresh()>lastRefresh) {
-            		result = credentials;
-            		lastRefresh = credentials.getLastRefresh();
-            	}
+                result = credentials;
             }
         }
         return result;

--- a/fortnoxAdapter/src/main/java/org/notima/businessobjects/adapter/fortnox/FortnoxAdapter.java
+++ b/fortnoxAdapter/src/main/java/org/notima/businessobjects/adapter/fortnox/FortnoxAdapter.java
@@ -147,8 +147,7 @@ public class FortnoxAdapter extends BasicBusinessObjectFactory<
 		if (getClientManager()!=null) {
 			fci = getClientManager().getClientInfoByOrgNo(orgNo);
 		}
-		String clientId = fci.getClientId() != null ? fci.getClientId() : getClientManager().getDefaultClientId();
-		client = new FortnoxClient3(clientId, fci.getClientSecret(), new FileCredentialsProvider(orgNo));
+		client = new FortnoxClient3(new FileCredentialsProvider(orgNo));
 	}
 	
 	/**

--- a/fortnoxAdapter/src/main/java/org/notima/businessobjects/adapter/fortnox/FortnoxAdapter.java
+++ b/fortnoxAdapter/src/main/java/org/notima/businessobjects/adapter/fortnox/FortnoxAdapter.java
@@ -147,7 +147,8 @@ public class FortnoxAdapter extends BasicBusinessObjectFactory<
 		if (getClientManager()!=null) {
 			fci = getClientManager().getClientInfoByOrgNo(orgNo);
 		}
-		client = new FortnoxClient3(getClientManager().getDefaultClientId(), fci.getClientSecret(), new FileCredentialsProvider(orgNo));
+		String clientId = fci.getClientId() != null ? fci.getClientId() : getClientManager().getDefaultClientId();
+		client = new FortnoxClient3(clientId, fci.getClientSecret(), new FileCredentialsProvider(orgNo));
 	}
 	
 	/**

--- a/fortnoxAdapter/src/main/java/org/notima/fortnox/command/AddClient.java
+++ b/fortnoxAdapter/src/main/java/org/notima/fortnox/command/AddClient.java
@@ -92,9 +92,6 @@ public class AddClient implements Action {
 					&& clientSecret!=null && 
 					(refreshToken != null || legacy)) {
 				FortnoxClient3 fc3 = fa.getClient();
-				if (clientSecret!=null && !fc3.hasClientSecret()) {
-					fc3.setClientSecret(clientSecret);
-				}
 				if (legacy) {
 					if(accessToken == null && authorizationCode != null) {
 						accessToken = fc3.getLegacyAccessToken(authorizationCode, clientSecret);


### PR DESCRIPTION
Vad jag kan se är detta den ända ändringen som behövs. FortnoxClient3 ska sedan veta vilket id som ska användas.
Det behöver alltså inte finnas med i Credentials.json