### PR TITLE
karaf CLI supports refresh locks of FortnoxCredentials

### DIFF
--- a/fortnoxAdapter/src/main/java/org/notima/fortnox/command/LockCredentials.java
+++ b/fortnoxAdapter/src/main/java/org/notima/fortnox/command/LockCredentials.java
@@ -1,0 +1,55 @@
+package org.notima.fortnox.command;
+
+import java.util.List;
+
+import org.apache.karaf.shell.api.action.Action;
+import org.apache.karaf.shell.api.action.Argument;
+import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.lifecycle.Reference;
+import org.apache.karaf.shell.api.action.lifecycle.Service;
+import org.apache.karaf.shell.api.console.Session;
+import org.notima.api.fortnox.clients.FortnoxCredentials;
+import org.notima.api.fortnox.oauth2.FileCredentialsProvider;
+import org.notima.generic.businessobjects.BusinessPartnerList;
+import org.notima.generic.ifacebusinessobjects.BusinessObjectFactory;
+
+@Command(scope = _FortnoxCommandNames.SCOPE, name = "lock-credentials", description = "Lock fortnox credentials to prevent them from being refreshed")
+@Service
+public class LockCredentials extends FortnoxCommand implements Action {
+	
+	@Reference 
+	Session sess;
+
+    @Argument(index = 0, name = "orgNo", description ="The orgnos of clients to lock credentials for. All credentials will be locked if this is omitted", required = false, multiValued = true)
+    private String[] orgNos;
+
+	@SuppressWarnings("rawtypes")
+	@Reference
+	private List<BusinessObjectFactory> bofs;
+
+    @Override
+    public Object execute() throws Exception {
+        if(orgNos == null) {
+			for (BusinessObjectFactory bf : bofs) {
+				if ("Fortnox".equals(bf.getSystemName())) {
+					BusinessPartnerList<?> bpl = bf.listTenants();
+					orgNos = new String[bpl.getBusinessPartner().size()];
+					for(int i = 0; i < orgNos.length; i++) {
+						orgNos[i] = bpl.getBusinessPartner().get(i).getTaxId();
+					}
+				}
+			}
+		}
+
+        for(String orgNo : orgNos) {
+			FileCredentialsProvider credentialsProvider = new FileCredentialsProvider(orgNo);
+            List<FortnoxCredentials> credentials = credentialsProvider.getAllCredentials();
+            for(FortnoxCredentials cred : credentials) {
+                cred.lockRefresh();
+				credentialsProvider.setCredentials(cred);
+                sess.getConsole().printf("Credentials for %s (%s) have been \u001B[31mlocked\u001B[0m\n", orgNo, cred.getAccessTokenAbbreviated());
+            }
+        }
+        return null;
+    }
+}

--- a/fortnoxAdapter/src/main/java/org/notima/fortnox/command/UnlockCredentials.java
+++ b/fortnoxAdapter/src/main/java/org/notima/fortnox/command/UnlockCredentials.java
@@ -1,0 +1,55 @@
+package org.notima.fortnox.command;
+
+import java.util.List;
+
+import org.apache.karaf.shell.api.action.Action;
+import org.apache.karaf.shell.api.action.Argument;
+import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.lifecycle.Reference;
+import org.apache.karaf.shell.api.action.lifecycle.Service;
+import org.apache.karaf.shell.api.console.Session;
+import org.notima.api.fortnox.clients.FortnoxCredentials;
+import org.notima.api.fortnox.oauth2.FileCredentialsProvider;
+import org.notima.generic.businessobjects.BusinessPartnerList;
+import org.notima.generic.ifacebusinessobjects.BusinessObjectFactory;
+
+@Command(scope = _FortnoxCommandNames.SCOPE, name = "unlock-credentials", description = "Unlock fortnox credentials to allow them to be refreshed")
+@Service
+public class UnlockCredentials extends FortnoxCommand implements Action {
+	
+	@Reference 
+	Session sess;
+
+    @Argument(index = 0, name = "orgNo", description ="The orgnos of clients to unlock credentials for. All credentials will be unlocked if this is omitted", required = false, multiValued = true)
+    private String[] orgNos;
+
+	@SuppressWarnings("rawtypes")
+	@Reference
+	private List<BusinessObjectFactory> bofs;
+
+    @Override
+    public Object execute() throws Exception {
+        if(orgNos == null) {
+			for (BusinessObjectFactory bf : bofs) {
+				if ("Fortnox".equals(bf.getSystemName())) {
+					BusinessPartnerList<?> bpl = bf.listTenants();
+					orgNos = new String[bpl.getBusinessPartner().size()];
+					for(int i = 0; i < orgNos.length; i++) {
+						orgNos[i] = bpl.getBusinessPartner().get(i).getTaxId();
+					}
+				}
+			}
+		}
+
+        for(String orgNo : orgNos) {
+			FileCredentialsProvider credentialsProvider = new FileCredentialsProvider(orgNo);
+            List<FortnoxCredentials> credentials = credentialsProvider.getAllCredentials();
+            for(FortnoxCredentials cred : credentials) {
+                cred.unlockRefresh();
+				credentialsProvider.setCredentials(cred);
+                sess.getConsole().printf("Credentials for %s (%s) have been \u001B[32munlocked\u001B[0m\n", orgNo, cred.getAccessTokenAbbreviated());
+            }
+        }
+        return null;
+    }
+}

--- a/fortnoxAdapter/src/main/java/org/notima/fortnox/command/table/CredentialTable.java
+++ b/fortnoxAdapter/src/main/java/org/notima/fortnox/command/table/CredentialTable.java
@@ -11,6 +11,10 @@ import org.notima.businessobjects.adapter.tools.table.GenericTable;
 
 public class CredentialTable extends GenericTable {
 
+	public static final String ANSI_RED = "\u001B[31m";
+	public static final String ANSI_GREEN = "\u001B[32m";
+	public static final String ANSI_RESET = "\u001B[0m";
+
 	private DateFormat dfmt = new SimpleDateFormat("yy-MM-dd HH:mm:ss");
 	
 	private List<FortnoxCredentials> creds;
@@ -27,6 +31,7 @@ public class CredentialTable extends GenericTable {
 		column("Last refresh");
 		column("Timestamp");
 		column("Expires in");
+		column("Lock status");
 	
 		addRows();
 		
@@ -78,7 +83,8 @@ public class CredentialTable extends GenericTable {
 				cred.getRefreshTokenAbbreviated(),
 				dfmt.format(cred.getLastRefreshAsDate()),
 				cred.getLastRefresh(),
-				cred.getExpiresIn());
+				cred.getExpiresIn(),
+				cred.isRefreshLocked() ? ANSI_RED+"[Locked]"+ANSI_RESET : ANSI_GREEN+"[Unlocked]"+ANSI_RESET);
 		
 	}
 	
@@ -89,6 +95,7 @@ public class CredentialTable extends GenericTable {
 				cred.getClientId(),
 				cred.getLegacyTokenAbbreviated(),
 				"Legacy", 
+				"N/A",
 				"N/A",
 				"N/A",
 				"N/A",


### PR DESCRIPTION
The following features have been added:
- command `fortnox:list-fortnox-credentials` has an extra column in the table output for lock status
- command `fortnox:list-fortnox-credentials` can show all credentials for a list of orginazation numbers (or all clients if no organization number is specified)
- new command `fortnox:lock-credentials` for blocking credentials from being refreshed
- new command `fortnox:unlock-credentials` for allowing credentials to be refreshed